### PR TITLE
Lowercase all resources in book.resources

### DIFF
--- a/src/models/book/book.coffee
+++ b/src/models/book/book.coffee
@@ -115,11 +115,15 @@ class LYT.Book
       # If fail, then fail
       got.fail -> deferred.reject BOOK_CONTENT_RESOURCES_ERROR
 
-      got.then (@resources) =>
+      got.then (resources) =>
         ncc = null
 
         # Process the resources hash
-        for own localUri, uri of @resources
+        for own localUri, uri of resources
+
+          # We lowercase all resource lookups to avoid general case-issues
+          localUri = localUri.toLowerCase()
+
           # Each resource is identified by its relative path,
           # and contains the properties `url` and `document`
           # (the latter initialized to `null`)

--- a/src/models/book/dtb/section.coffee
+++ b/src/models/book/dtb/section.coffee
@@ -44,7 +44,7 @@ class LYT.Section
     log.message "Section: loading(\"#{@url}\")"
     # trim away everything after the filename.
     file = @url.replace /#.*$/, ""
-    url  = @resources[file]?.url
+    url  = @resources[file.toLowerCase()]?.url
     if url is undefined
       log.error "Section: load: url is undefined"
     @document = new LYT.SMILDocument this, url
@@ -66,7 +66,7 @@ class LYT.Section
     return [] unless @document?.state() is "resolved"
     urls = []
     for file in @document.getAudioReferences()
-      url = @resources[file]?.url
+      url = @resources[file.toLowerCase()]?.url
       urls.push url if url
     urls
 

--- a/src/models/book/dtb/segment.coffee
+++ b/src/models/book/dtb/segment.coffee
@@ -53,7 +53,7 @@ class LYT.Segment
     @end         = data.end
     @canBookmark = data.canBookmark
     @section     = section
-    @audio       = @section.resources[data.audio.src]?.url
+    @audio       = @section.resources[data.audio?.src?.toLowerCase()]?.url
     @data        = data
     # Will be initialized in the load() method:
     @text        = null
@@ -73,7 +73,8 @@ class LYT.Segment
       log.message "Segment: loading #{@url()}"
       # Parse transcript content
       [@contentUrl, @contentId] = @data.text.src.split "#"
-      resource = section.resources[@contentUrl]
+      resource = section.resources[@contentUrl.toLowerCase()]
+
       if not resource
         log.error "Segment: no absolute URL for content #{@contentUrl}"
         @_deferred.reject()

--- a/src/models/book/dtb/textcontentdocument.coffee
+++ b/src/models/book/dtb/textcontentdocument.coffee
@@ -13,5 +13,5 @@ class LYT.TextContentDocument extends LYT.DTBDocument
       return if item.data("resolved")?
       url = item.attr("src")
       url = url.substr url.lastIndexOf('/') + 1 unless url.lastIndexOf('/') == -1
-      item.attr "src", resources[url]?.url
+      item.attr "src", resources[url.toLowerCase()]?.url
       item.data "resolved", "yes" # Mark as already-processed


### PR DESCRIPTION
This is not following the standard strictly, but since some books are
produced with filename case-issues, this fix is sadly necessary. It's very
unlikely that two files with the same filename but different casing will
occur.

Fixes #561, #580
