### PR TITLE
Add robots.txt that disallow any crawling of LYT. Fixes issue #516

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Are we sure we want to do this? Won't this wipe out the E17 Direkte link when searching in Google? (that is, in the Nota implementation of LYT)
