### PR TITLE
Only set firstPlay when actually playing

### DIFF
--- a/src/controllers/player.coffee
+++ b/src/controllers/player.coffee
@@ -230,8 +230,7 @@ LYT.player =
     result.done =>
       log.message "Player: book #{@book.id} loaded"
       # Never start playing if firstplay flag set
-      if not @firstPlay
-        @play() if play
+      @play if not @firstPlay and play
 
     result.fail (error) -> log.error "Player: failed to load book, reason #{error}"
 


### PR DESCRIPTION
This prevents an issue with the player where (in iOS which doesn't support auto playback), selecting a book from the bookshelf, then go back and select a new one, would result in an infinity-spinner (load icon).

This issue was due to setting the `Lyt.player.firstPlay` variable to early.
