### PR TITLE
Forward-slashes in Windows builds

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -110,6 +110,11 @@ task "html", "Build HTML", (options) ->
     scripts = scripts.concat(coffee.filter coffeeScripts, "src", "javascript")
 
   template = html.interpolate template, (html.styleSheets [stylesheet, 'css/screen.css']), 'cake:stylesheets'
+
+  # We don't want Windows builds to have backward-slashes
+  if process.platform is 'win32' or fs.path.sep is "\\"
+    scripts = (script.replace(/\\/g, "/") for script in scripts)
+
   template = html.interpolate template, html.scriptTags(scripts), "cake:scripts"
 
   fs.writeFileSync "build/index.html", template


### PR DESCRIPTION
The only _real_ problem I could find with building on Windows machines, was that all the `src` attributes of `<script>` tags contained backward-slashes. I've fixed this, and that should resolve [NOTA-129](https://notalib.atlassian.net/browse/NOTA-129)
