### PR TITLE
Lowercase all resources in book.resources

### DIFF
--- a/src/models/book/book.coffee
+++ b/src/models/book/book.coffee
@@ -100,11 +100,15 @@ class LYT.Book
       # If fail, then fail
       got.fail -> deferred.reject BOOK_CONTENT_RESOURCES_ERROR
 
-      got.then (@resources) =>
+      got.then (resources) =>
         ncc = null
 
         # Process the resources hash
-        for own localUri, uri of @resources
+        for own localUri, uri of resources
+
+          # We lowercase all resource lookups to avoid general case-issues
+          localUri = localUri.toLowerCase()
+
           # Each resource is identified by its relative path,
           # and contains the properties `url` and `document`
           # (the latter initialized to `null`)

--- a/src/models/book/dtb/section.coffee
+++ b/src/models/book/dtb/section.coffee
@@ -43,7 +43,7 @@ class LYT.Section
 
     log.message "Section: loading(\"#{@url}\")"
     # trim away everything after the filename.
-    file = @url.replace /#.*$/, ""
+    file = (@url.replace /#.*$/, "").toLowerCase()
     if not file of @book.resources
       log.error "Section: load: url not found in resources: #{file}"
 
@@ -67,7 +67,7 @@ class LYT.Section
     return [] unless @document?.state() is "resolved"
     urls = []
     for file in @document.getAudioReferences()
-      url = @resources[file]?.url
+      url = @resources[file.toLowerCase()]?.url
       urls.push url if url
     urls
 

--- a/src/models/book/dtb/segment.coffee
+++ b/src/models/book/dtb/segment.coffee
@@ -47,7 +47,7 @@ class LYT.Segment
     @start       = data.start
     @end         = data.end
     @canBookmark = data.canBookmark
-    @audio       = document.book.resources[data.audio.src]?.url
+    @audio       = @section.resources[data.audio?.src?.toLowerCase()]?.url
     @data        = data
     @el          = data.par
     @document    = document
@@ -68,7 +68,7 @@ class LYT.Segment
 
     # Parse transcript content
     [@contentUrl, @contentId] = @data.text.src.split "#"
-    resource = @document.book.resources[@contentUrl]
+    resource = @document.book.resources[@contentUrl.toLowerCase()]
     if not resource
       log.error "Segment: no absolute URL for content #{@contentUrl}"
       @_deferred.reject()
@@ -83,7 +83,7 @@ class LYT.Segment
         log.error "Unable to get TextContentDocument for #{resource.url}: #{status}, #{error}"
         @_deferred.reject()
 
-    return @_deferred.promise()
+    @_deferred.promise()
 
   url: -> "#{@document.filename}##{@id}"
 

--- a/src/models/book/dtb/textcontentdocument.coffee
+++ b/src/models/book/dtb/textcontentdocument.coffee
@@ -13,5 +13,5 @@ class LYT.TextContentDocument extends LYT.DTBDocument
       return if item.data("resolved")?
       url = item.attr("src")
       url = url.substr url.lastIndexOf('/') + 1 unless url.lastIndexOf('/') == -1
-      item.attr "src", resources[url]?.url
+      item.attr "src", resources[url.toLowerCase()]?.url
       item.data "resolved", "yes" # Mark as already-processed


### PR DESCRIPTION
This is not following the standard strictly, but since some books are
produced with filename case-issues, this fix is sadly necessary. It's very
unlikely that two files with the same filename but different casing will
occur.

This should go on `master` as well, when possible
