### PR TITLE
Remember to lowercase all SMIL files when requested

### DIFF
--- a/src/models/book/book.coffee
+++ b/src/models/book/book.coffee
@@ -203,9 +203,10 @@ class LYT.Book
     ordered
 
   getSMIL: (url) ->
+    url = url.toLowerCase()
     deferred = jQuery.Deferred()
     if not (url of @resources)
-      return deferred.promise().reject()
+      return deferred.reject()
 
     smil = @resources[url]
     smil.document or= new LYT.SMILDocument smil.url, this


### PR DESCRIPTION
Fixes an issue when an old lastmark/bookmark would result in books not loading, due to uppercase/lowercase issues with fetching SMIL files.
