### PR TITLE
Add uglifyjs as a dependency and use the local version for minifying

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "w3cjs": "~0.1.20",
     "lyt-grinder": "~0.0.1",
     "coffeelint": "~0.6.1",
-    "ftpkick": "~0.0.3"
+    "ftpkick": "~0.0.3",
+    "uglify-js": "~2.4.6"
   },
 
   "repository": {


### PR DESCRIPTION
Adds `uglifyjs2` as a dependency to `package.json` so that we keep track of it.

It'll now be installed when doing a `npm install` and the `Cakefile` will use the locally installed version
