### PR TITLE
Only send one GetItemById request when viewing book details

### DIFF
--- a/src/controllers/control.coffee
+++ b/src/controllers/control.coffee
@@ -256,18 +256,14 @@ LYT.control =
     promise.done ->
       if type is 'pagebeforeshow'
         process = LYT.catalog.getDetails(params.book)
+          .fail (error, msg) ->
+            log.message "Control: bookDetails: failed with error #{error} and msg #{msg}"
           .done (details) ->
             LYT.render.hideOrShowButtons(details)
+            LYT.render.bookDetails(details, content)
+            LYT.render.setPageTitle details.title
+            content.children().show()
         LYT.loader.register "Loading book", process, 10
-
-      if type is 'pageshow'
-        process = LYT.catalog.getDetails(params.book)
-        .fail (error, msg) ->
-          log.message "Control: bookDetails: failed with error #{error} and msg #{msg}"
-        .done (details) ->
-          LYT.render.bookDetails(details, content)
-          LYT.render.setPageTitle details.title
-          content.children().show()
 
   # TODO: Move bookmarks list to separate page
   # TODO: Bookmarks and toc does not work properly after a forced refresh on the #book-index page. Needs to be fixed when force reloading the entire app.


### PR DESCRIPTION
For whatever reason we were calling `LYT.catalog.getDetails()` twice when viewing book details - one time on `'pagebeforeshow'`, another one on `'pageshow'`. This seemed redundant, and it works as expected when doing all the DOM magic in the promise created on `'pagebeforeshow'`
