### PR TITLE
Fixed several bugs in the loader implementation and seek command

### DIFF
--- a/src/controllers/player/load.coffee
+++ b/src/controllers/player/load.coffee
@@ -40,7 +40,8 @@ class LYT.player.command.load extends LYT.player.command
           @load()
         else
           @notify event.jPlayer.status
-      # else: nothing to do because this event is from the wrong file
+      else
+        @reject() # This load command has been superseded by another
 
     canplaythrough: (event) =>
       status = event.jPlayer.status

--- a/src/controllers/player/play.coffee
+++ b/src/controllers/player/play.coffee
@@ -19,15 +19,13 @@ class LYT.player.command.play extends LYT.player.command
   cancel: ->
     super()
     @el.jPlayer 'pause'
+    @_stop()
 
-    # We still receive "timeupdate" events after having paused the jPlayer
-    # element. @justCancelled is used to soak up any "timeupdate" events after
-    # pause, so we don't mess up the play() method in the player
-    @justCancelled = true
-
-  _stop: (event) ->
-    method = if @cancelled then @reject else @resolve
-    method.apply this, event.jPlayer.status
+  _stop: ->
+    if @cancelled
+      @reject()
+    else
+      @resolve()
 
   handles: ->
     playing: (event) =>
@@ -35,12 +33,12 @@ class LYT.player.command.play extends LYT.player.command
       @notify event.jPlayer.status
 
     timeupdate: (event) =>
-      if @playing and (event.jPlayer.status.paused or @justCancelled)
-        @_stop event
+      if @playing and (event.jPlayer.status.paused or @cancelled)
+        @_stop()
       else
         @notify event.jPlayer.status
 
-    ended: (event) => @_stop event
+    ended: (event) => @_stop()
 
-    pause: (event) => @_stop event
+    pause: (event) => @_stop()
 


### PR DESCRIPTION
With this commit several of the indefinite loader bugs should be fixed.
We've done this by proper use of deferreds in
LYT.player.seekSegmentOffset so that the loader will disappear on both
success and failure

We've also implemented a chain/queue of seek commands, so that several subsequent clicks on Forward15/Backwards15 will be chained.

One of the most severe bugs we fixed was that several `load` and `seek` commands could be active at the same time, though (of course) still interacting with the same `<audio>` element. This led to several race-conditions and would in a lot of cases result in the hanging loader.

(_we_ are @LDHGithub and I)
Test branch available at http://test.m.e17.dk/fixloader
