### PR TITLE
Fix issue where iOS player would stall if first click was on play button

### DIFF
--- a/src/controllers/player.coffee
+++ b/src/controllers/player.coffee
@@ -132,10 +132,10 @@ LYT.player =
       LYT.instrumentation.record 'ui:stop'
       @stop()
 
-    $('.lyt-play').click =>
+    $('.lyt-play').click (e) =>
       LYT.instrumentation.record 'ui:play'
       if @playClickHook
-        @playClickHook().done => @play()
+        @playClickHook(e).done => @play()
       else
         @play()
 
@@ -224,7 +224,16 @@ LYT.player =
       if @firstPlay and not Modernizr.autoplayback
         # The play click handler will call @playClickHook which enables the
         # player to start seeking.
-        @playClickHook = =>
+        @playClickHook = (e) =>
+
+          # If this is the first click by the user (on an iOS device), the
+          # playbackrate tests will fire off at the same time as this. For
+          # whatever reason, that makes the silentplay command stall after two
+          # timeupdate/progress events, and we never get any further. Therefore
+          # we need to stop the bubbling of the event
+          e.stopPropagation()
+          e.preventDefault()
+
           @playClickHook = null
           silentplay = new LYT.player.command.silentplay @el
           playPromise = silentplay.then =>

--- a/src/controllers/player/silentplay.coffee
+++ b/src/controllers/player/silentplay.coffee
@@ -27,5 +27,4 @@ class LYT.player.command.silentplay extends LYT.player.command
     timeupdate: metadataHandler
     loadedmetadata: metadataHandler
     progress: metadataHandler
-
     pause: (event) => @resolve event.jPlayer.status

--- a/src/support/modernizr/playbackrate.coffee
+++ b/src/support/modernizr/playbackrate.coffee
@@ -12,6 +12,7 @@
 # Note that these tests are asynchronous (use Modernizr.on)
 
 playbackLiveTest = (audio) ->
+  log.message "Tests: Playback live test (playbackratelive) is running"
   # Reset audio
   audio.currentTime = 0
   margin = 0.1
@@ -62,6 +63,7 @@ playbackLiveTest = (audio) ->
   audio.play()
 
 playbackTest = ->
+  log.message "Tests: Playback test (playbackrate) is running"
   margin = 0.1    # Margin that the measured playback rate should be within
   rate = 0.5      # Test rate
   duration = 7    # How long time to play the audio before measuring playback rate


### PR DESCRIPTION
If the first click issued by the user (on an iOS device) is on the play button, both the playbackrate tests and the `silentplay` command will be started at the same time. For some reason this makes the `silentplay` command hang and in turn the whole player. We fix this by stopping the click event from bubbling in the `LYT.player.playClickHook`
