### PR TITLE
Update ftpkick with implemented checkfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ npm-debug.log
 DEADJOE
 .externalToolBuilders
 .settings
+.lyt.checkfile.*

--- a/Cakefile
+++ b/Cakefile
@@ -49,13 +49,12 @@ task "deploy", "Deploys the build dir to $LYT_FTP_USER@host/$LYT_DESTINATION_DIR
   destination_dir = process.env.LYT_DESTINATION_DIR || process.env.USER
   ftp_user  = process.env.LYT_FTP_USER || "anonymous"
   ftp_password = process.env.LYT_FTP_PASSWORD
-  checkfile = process.env.LYT_FTP_CHECKFILE || ".lyt.checkfile"
+  checkfile = process.env.LYT_FTP_CHECKFILE || ".lyt.checkfile."
 
-  if options['force-deploy']
-    checkfile = null
+  force = options['force-deploy']
 
   for host in dev_hosts
-    checkfile = host + checkfile if checkfile
+    chkfile = checkfile + host
     do (host) ->
       console.log "Connecting to #{host}"
       ftpkick.connect(
@@ -64,7 +63,7 @@ task "deploy", "Deploys the build dir to $LYT_FTP_USER@host/$LYT_DESTINATION_DIR
         password: ftp_password
       ).then (kicker) ->
         console.log "Uploading to #{host}"
-        kicker.kick("build", destination_dir, checkfile).then(
+        kicker.kick("build", destination_dir, chkfile, force).then(
           (f) -> console.log "Successfully uploaded #{f.length} files for #{host}",
           (e) -> console.error "An error occurred", e if e.code isnt 550
         ).then ->

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "w3cjs": "~0.1.20",
     "lyt-grinder": "~0.0.1",
     "coffeelint": "~0.6.1",
-    "ftpkick": "~0.0.5",
+    "ftpkick": "~0.0.6",
     "uglify-js": "~2.4.6"
   },
 


### PR DESCRIPTION
I've updated the `ftpkick` package to implement a "checkfile", that saves the modification time for all uploaded files. Then it locally checks if the files in `build/` or whatever directory is newer than the one listed in the checkfile.

The checkfile is saved in the OS' temp dir, and the name of file can be altered (although this is unnecessary) with the environment variable `LYT_FTP_CHECKFILE`

This quickens up the `cake deploy` task _A LOT_ except for the first upload (where the checkfile hasn't been generated). It now takes less than a second on my machine.

This hasn't been tested on Windows, nor Linux, so if anyone would like to give it a try, please do before merging this.

**ps. remember to run `npm install` after pulling this - otherwise you won't update the `ftpkick` package**
