### PR TITLE
Use user-scalable to prevent flickering when loading page on mobile devices

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -10,7 +10,7 @@
 	<!-- View fullscreen on iOS devices if added to homescreen --> 
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-status-bar-style" content="black">
-	<meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1">
+	<meta name="viewport" content="width=device-width, user-scalable=no">
 	<link rel="apple-touch-icon-precomposed" href="apple-touch-icon-57x57-precomposed.png" />
 	<link rel="apple-touch-icon-precomposed" sizes="57x57" href="apple-touch-icon-57x57-precomposed.png" />
 	<link rel="apple-touch-icon-precomposed" sizes="72x72" href="apple-touch-icon-72x72-precomposed.png" />


### PR DESCRIPTION
This was as simple as replacing `minimum-scale=1, maximum-scale=1` with `user-scalable=no` in the viewport meta tag.

It prevents the iOS devices that I've tested on, from flickering when initially loading the page
