### PR TITLE
Show the 'currently playing'-icon on parent sections

### DIFF
--- a/src/view/render.coffee
+++ b/src/view/render.coffee
@@ -287,9 +287,12 @@ LYT.render = do ->
 
 
   createbookIndex: (items, view, book, root = null) ->
+    curSection = LYT.player.currentSection()
+    curParentID = curSection.id.substr 0, curSection.id.search /(\.\d$)|$/
+
     isPlaying = (item) ->
       return unless String(book.id) is String(LYT.player.book.id)
-      return unless item.ref is LYT.player.currentSection().ref
+      return unless item.ref is curSection.ref or curParentID is item.id
       return true
 
     sectionLink = (section, play = 'true') ->


### PR DESCRIPTION
Before this change _only_ the actual currently playing section would be
highlighted. Now, parent-sections of that section is hightlighted too in
the TOC.

Fixes #530
