### PR TITLE
Fix that the player stops when selecting the current active section

### DIFF
--- a/src/controllers/control.coffee
+++ b/src/controllers/control.coffee
@@ -345,6 +345,11 @@ LYT.control =
         LYT.render.content.focusEasing params.focusEasing if params.focusEasing
         LYT.render.content.focusDuration parseInt params.focusDuration if params.focusDuration
 
+        # If this section is already playing, don't do anything
+        if LYT.player.book? and params.fragment? and
+           params.fragment is LYT.player.currentSection().fragment
+          return
+
         log.message "Control: bookPlay: loading book #{params.book}"
 
         process = LYT.player.load params.book, smilReference, offset, play


### PR DESCRIPTION
Fixes the bug where the player would start from the beginning of the chapter when clicking the chapter that was already active/playing. This wasn't the desired behaviour.

Fixes [NOTA-277](https://notalib.atlassian.net/browse/NOTA-277)
