### PR TITLE
Fix that the player would pause when selecting the active book from the bookshelf

### DIFF
--- a/src/controllers/control.coffee
+++ b/src/controllers/control.coffee
@@ -326,6 +326,10 @@ LYT.control =
     promise.fail -> log.error 'Control: bookPlay: unable to get login'
     promise.done ->
       if type is 'pageshow'
+        # If we're already playing this book, and we're coming from the
+        # bookshelf, we just continue playing
+        if LYT.player.book?.id is params.book and params.from is 'bookshelf'
+          return
 
         # Switch to different (part of) book
         # Because of bad naming, sections are here actually SMIL

--- a/src/view/render.coffee
+++ b/src/view/render.coffee
@@ -16,18 +16,19 @@ LYT.render = do ->
   defaultCover = '/images/icons/default-cover.png'
 
   # Create a book list-item which links to the `target` page
-  bookListItem = (target, book) ->
+  bookListItem = (target, book, from) ->
     info = []
     info.push book.author if book.author?
     info.push getMediaType(book.media) if book.media?
     info = info.join '&nbsp;&nbsp;|&nbsp;&nbsp;'
+    from = "&from=#{from}" if from?
 
     if String(book.id) is String(LYT.player.book?.id)
       nowPlaying = '<div class="book-now-playing"></div>'
 
     element = jQuery """
       <li data-book-id="#{book.id}">
-        <a class="gatrack book-play-link" data-ga-action="Vælg" ga-book-id="#{book.id}" ga-book-title="#{(book.title or '').replace '"', ''}" href="##{target}?book=#{book.id}">
+        <a class="gatrack book-play-link" data-ga-action="Vælg" ga-book-id="#{book.id}" ga-book-title="#{(book.title or '').replace '"', ''}" href="##{target}?book=#{book.id + from}">
           <div class="cover-image-frame">
             <img class="ui-li-icon cover-image">
           </div>
@@ -157,7 +158,7 @@ LYT.render = do ->
     list.empty() if page is 1 or zeroAndUp
 
     for book in books
-      li = bookListItem 'book-player', book
+      li = bookListItem 'book-player', book, 'bookshelf'
       removeLink = jQuery """<a class="remove-book" href="#">#{LYT.i18n('Remove')} #{book.title}</a>"""
       attachClickEvent removeLink, book, li
       li.append removeLink


### PR DESCRIPTION
We're fixing this with an ugly fix, that appends a "from" parameter to
the url, when redirecting to the book player from the bookshelf. But it
works...

This method might solve the other URL related problems we've had, until the transition to a better application structure. Fixes [NOTA-230](https://notalib.atlassian.net/browse/NOTA-230)
