### PR TITLE
Fix scrollbar issue caused by weird padding

### DIFF
--- a/scss/screen.scss
+++ b/scss/screen.scss
@@ -372,8 +372,7 @@ img.e17-logo {
         top: 0;
       }
       .ui-btn-text .book-play-link {
-        padding-left: 45px;
-        padding-top: 0.2em;
+        padding: 0.2em 0 0 45px;
       }
 
       .cover-image {


### PR DESCRIPTION
Fixes an issue where the scrollbar would show up in iOS and Chrome on Linux in the bookshelf view. This was caused by a padding that overflowed the containing element.

Fixes [NOTA-231](https://notalib.atlassian.net/browse/NOTA-231)
