### PR TITLE
Remove underline from context-viewer internal links

### DIFF
--- a/scss/screen.scss
+++ b/scss/screen.scss
@@ -1169,25 +1169,7 @@ li.ui-li h3.no-search-results {
 
 #book-context-content {
   overflow-y: scroll;
-  a {
-    color: inherit;
 
-    &.external {
-      color: crimson;
-    }
-  }
-
-  p {
-    margin-top: 0.3em;
-    opacity: 0.4;
-    line-height: 1.37;
-    &.active {
-     opacity: 1;
-    }
-  }
-}
-
-#book-context-content {
   &.word-highlight {
     &.is-word-marked {
       p {
@@ -1201,6 +1183,26 @@ li.ui-li h3.no-search-results {
       span.word.active {
         opacity: 1;
       }
+    }
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+
+    &.external {
+      color: crimson;
+      text-decoration: underline;
+    }
+  }
+
+  p {
+    margin-top: 0.3em;
+    opacity: 0.4;
+    line-height: 1.37;
+
+    &.active {
+     opacity: 1;
     }
   }
 


### PR DESCRIPTION
So that journals like Berlingske Tidende looks proper.