### PR TITLE
Always lookup lowercase uri in @resources

### DIFF
--- a/src/view/render/content.coffee
+++ b/src/view/render/content.coffee
@@ -219,7 +219,7 @@ LYT.render.content = do ->
   # scrolls around when appropriate
   renderContext = (segment, view, delta) ->
     book = segment.document.book
-    html = book.resources[segment.contentUrl].document
+    html = book.resources[segment.contentUrl.toLowerCase()].document
     source = html.source[0]
     isCartoon = html.isCartoon()
 


### PR DESCRIPTION
Fixes an issue that prevented playing and/or viewing the contents of a range of journals (Inspiration, etc).