### PR TITLE
Don't depend on deprecated --join coffee argument

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -228,11 +228,15 @@ coffee = do ->
   # Will *always* produce both concatenated and minified
   # versions if concat is true.
   compile = (files, output, concat, callback) ->
-    cmd = "#{config.coffee} --compile"
-    cmd += " --join #{concat}.js" if concat
-    files = q(files).join " "
-    cmd += " --output #{q output} #{files}"
-    exec cmd, (err, stdout, stderr) ->
+    # "cat" (read the contents of) all files
+    catCmd = "cat #{files}"
+    # Compile the contents, read from standard input
+    coffeeCmd = "#{config.coffee} --compile --stdio --output #{q output}"
+    # Pipe all the output to a single file, if concat flag is on
+    joinPart = "> #{fs.path.join output, concat + ".js"}" if concat
+
+    fullCmd = "#{catCmd} | #{coffeeCmd} #{joinPart}"
+    exec fullCmd, (err, stdout, stderr) ->
       throw err if err?
       console.log stderr if stderr
       if concat


### PR DESCRIPTION
This commit shouldn't change the resulting file(s) in any way, but just do the concatenating of all the coffee script files in the preferred way.

As of coffee-script `1.8.0` the `--join` functionality has been deprecated. See (https://github.com/jashkenas/coffeescript/issues/3472).

As this is a pretty simple thing to "fix", I think this is worth doing for future-proofing the build system.
@mzedeler , @m-abs ?
