### PR TITLE
Fix highlighting of MTM books

### DIFF
--- a/scss/_application.scss
+++ b/scss/_application.scss
@@ -1218,7 +1218,15 @@ li.ui-li h3.no-search-results {
     line-height: 1.37;
 
     &.active {
-     opacity: 1;
+      opacity: 1;
+
+      span.sentence {
+        opacity: 0.4;
+
+        &.active {
+          opacity: 1;
+        }
+      }
     }
   }
 

--- a/src/view/render/content.coffee
+++ b/src/view/render/content.coffee
@@ -181,6 +181,7 @@ LYT.render.content = do ->
     panZoomImage segment, image, area, renderDelta
 
   prevActive = null
+  prevActiveParagraph = null
   segmentIntoView = (view, segment) ->
     el = view.find "##{segment.contentId}"
     isWordMarked = !!view.find( 'span.word' ).length
@@ -194,22 +195,27 @@ LYT.render.content = do ->
         # wordHighlighting is disabled, this would disable highlighting completely
         # for this book. Therfor we find the closest p-element and treat it like
         # it's the active element.
-        # We assume that the book structure is <p> -> <span id="#{segment.contentId}">,
-        # so we select the closest p parent to the el.
         isWordMarked = false
-        el = el.closest "p"
 
     if not isWordMarked
       # Not a word-marked book, set style to highlight paragraphs
       view.removeClass 'is-word-marked'
 
     # Remove highlighting of previous element
-    if prevActive
-      prevActive.removeClass "active"
+    prevActive.removeClass "active" if prevActive
+    prevActiveParagraph.removeClass "active" if prevActiveParagraph
+
+    # We assume that the book structure is <p> -> <span id="#{segment.contentId}">,
+    # so we select the closest p parent to the el.
+    unless el.is "p"
+      parentParagraph = el.closest "p"
 
     # Highlight element and scroll to element
     if el.length
       prevActive = el.addClass "active"
+      if parentParagraph
+        prevActiveParagraph = parentParagraph.addClass "active"
+
       if view.is ':visible'
         view.scrollTo( el, 100, { offset: -10 } )
       else


### PR DESCRIPTION
Fixes [NOTA-2285](https://notalib.atlassian.net/browse/NOTA-2285)

Some MTM books have content in the following format:
`<p> -> <span> -> <a> -> Text`
for each paragraph. We use:
`<p> -> <a> -> Text`

Problem is, that our books don't use the span element inside, and so we don't highlight their books properly. This fixes it, by assuming **all** books have a containing `<p>` element for each paragraph, and then highlighting the containing `<p>` element, even if that is not the element being referenced from the `SMIL` file.. I think all our books have that (at least our stylesheet assume it), but we should probably test this on a few books before pulling.

The problem with the current solution is, that we only assume that `<p>` elements get referenced from the `SMIL` files. That is not true. In the case of MTM's books, sometimes it's the contained `<span>` tag that gets referenced. Because we're using `opacity` to highlight different tags, we have all `<p>` tags set to `opacity: 0.4` by default, and when they're `.active` they get a `opacity: 1`.

@m-abs or @dfg-nota could you take a look at this and see if I'm missing something totally?