### PR TITLE
Use cogwheel as settings icon everywhere

### DIFF
--- a/html/pages/book-player.html
+++ b/html/pages/book-player.html
@@ -37,15 +37,15 @@
           data-l10n="Set bookmark">Sæt bogmærke</a>
 
         <a
+          id="book-settings-button"
           class="gatrack"
-          href="#settings"
           data-role="button"
           role="button"
-          id="book-settings-button"
-          data-icon="book_settings_icn"
+          href="#settings"
+          data-icon="settings_menu_icn"
           data-iconpos="notext"
           data-iconshadow="false"
-          data-l10n="Book Settings">Bogindstillinger</a>
+          data-l10n="Settings">Indstillinger</a>
       </div>
     </div>
 


### PR DESCRIPTION
Fixer de problemer der er beskrevet nederst i [NOTA-2086](https://notalib.atlassian.net/browse/NOTA-2086)

Vi bør bruge det samme ikon for indstillinger alle steder. Jeg synes "Gear"'et giver mere mening generelt end de to "A"'er, men jeg hører lige Anders når han kommer hjem fra ferie.

@andmand ?