### PR TITLE
Use simple object persistence if localstorage isn't available

### DIFF
--- a/src/config/config.coffee
+++ b/src/config/config.coffee
@@ -14,6 +14,9 @@
 
 # ## Central system configuration
 LYT.config =
+  # If set, this changes document.domain to the given value. Useful when
+  # serving the player from a subdomain like m.nota.dk
+  originDomain: "nota.dk"
 
   # ### LYT.rpc function config
   rpc:

--- a/src/config/config.dev.coffee
+++ b/src/config/config.dev.coffee
@@ -11,5 +11,7 @@ jQuery.extend log,
   receiver: 'local'
 
 jQuery.extend LYT.config,
+  originDomain: null
+
   settings:
     showAdvanced: yes

--- a/src/controllers/router.coffee
+++ b/src/controllers/router.coffee
@@ -20,6 +20,11 @@
 
 # -------------------
 
+# The first thing we do is to set document.domain to "nota.dk" since this will
+# allow the player on subdomain to pass origin checks to the superdomain
+if LYT.config?.originDomain
+  document.domain = LYT.config.originDomain
+
 LYT.var =
   next: null # store nextpage
 


### PR DESCRIPTION
This is a possible fix for MS-1333, that a lot of users have
experienced. Since private mode Safari (and maybe others) exposes
localStorage, but doesn't persist anything in it, LYT was tricked into
believing that it actually saved the users credentials.

Now if localStorage doesn't persist, we just save data in an object in a
closure.

I've removed some "functionality" of the LYT.cache module - but this "functionality" is hopelessly outdated (no-one will ever experience a DATA_QUOTA_EXCEEDED fault with the minimal amount of data we're saving) - and the strategy of dealing with such an error was way too elaborate.

@m-abs @dfg-nota You should probably be aware of this limitation of localStorage - but I hope that you'll be using a module to abstract away these problems.